### PR TITLE
syntaxtree not compiling [fixed]

### DIFF
--- a/Semantic_Analysis/syntaxtree_part3/ast.c
+++ b/Semantic_Analysis/syntaxtree_part3/ast.c
@@ -1,4 +1,6 @@
 #include "ast.h"
+Node * myhead;
+
 void bfs(Node *head)
 {
     Node *arr[100];

--- a/Semantic_Analysis/syntaxtree_part3/ast.h
+++ b/Semantic_Analysis/syntaxtree_part3/ast.h
@@ -13,7 +13,7 @@ typedef struct node{
     int ival;
     float fval;
 }Node;
-Node * myhead;
+extern Node * myhead;
 void bfs(Node* head);
 void dfs(Node * head);
 void addchild(Node * head,Node * child);

--- a/Semantic_Analysis/syntaxtree_part3/parser.y
+++ b/Semantic_Analysis/syntaxtree_part3/parser.y
@@ -6,7 +6,7 @@
 extern FILE* yyin;
 extern int yylineno;
 int n=1;
-
+extern int yylex(void);
 %}
 
 %token <tree> PROGRAM INTEGER_KEYWORD REAL_KEYWORD BOOLEAN_KEYWORD CHAR_KEYWORD VAR


### PR DESCRIPTION
compiling in syntaxtree_part3 gives error:
/usr/bin/ld: /tmp/cciqKie5.o:(.bss+0x0): multiple definition of myhead'; /tmp/ccb3DVEo.o:(.bss+0x28): first defined here
/usr/bin/ld: /tmp/cceQ18HD.o:(.bss+0x0): multiple definition of myhead'; /tmp/ccb3DVEo.o:(.bss+0x28): first defined here
collect2: error: ld returned 1 exit status

fixed by defining it in ast.c and using extern in ast.h
also fixed a warning from yyerror